### PR TITLE
Fixed warnings

### DIFF
--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -10,41 +10,33 @@ extern crate anyhow;
 extern crate cpal;
 extern crate ringbuf;
 
-use cpal::{
-    traits::{DeviceTrait, HostTrait, StreamTrait},
-    HostId,
-};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ringbuf::RingBuffer;
-use std::env;
 
 const LATENCY_MS: f32 = 150.0;
 
 fn main() -> Result<(), anyhow::Error> {
-    // Manually check for flags. Can be passed through cargo with -- e.g.
-    // cargo run --release --example beep --features jack -- --jack
-    let args: Vec<String> = env::args().collect();
-    let mut jack_flag = false;
-    for arg in args {
-        if arg == "--jack" {
-            jack_flag = true;
-        }
-    }
-
-    // Condintionally compile with jack if the feature is specified.
+    // Conditionally compile with jack if the feature is specified.
     #[cfg(all(
         any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
         feature = "jack"
     ))]
-    let host = if jack_flag {
+    // Manually check for flags. Can be passed through cargo with -- e.g.
+    // cargo run --release --example beep --features jack -- --jack
+    let host = if std::env::args()
+        .collect::<String>()
+        .contains(&String::from("--jack"))
+    {
         cpal::host_from_id(cpal::available_hosts()
             .into_iter()
-            .find(|id| *id == HostId::Jack)
+            .find(|id| *id == cpal::HostId::Jack)
             .expect(
                 "make sure --features jack is specified. only works on OSes where jack is available",
             )).expect("jack host unavailable")
     } else {
         cpal::default_host()
     };
+
     #[cfg(any(
         not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd")),
         not(feature = "jack")

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -108,7 +108,7 @@ impl Device {
     }
 
     pub fn supported_configs(&self) -> Vec<SupportedStreamConfigRange> {
-        let mut f = match self.default_config() {
+        let f = match self.default_config() {
             Err(_) => return vec![],
             Ok(f) => f,
         };


### PR DESCRIPTION
So, the examples run fine on my setup, maybe check on yours too, but I think they are ok.
I had to remove the `const TEMP_BUFFER_SIZE` and `temp_input_buffer_size` and `temp_input_buffer_index` fields in LocalProcessHandler because they were not used, can you confirm we don't need those?